### PR TITLE
Dune data analysis

### DIFF
--- a/src/download_swaps.py
+++ b/src/download_swaps.py
@@ -9,6 +9,7 @@ def get_swaps(use_cache):
             swaps_by_block = pickle.load(f)
     else:
         swaps_by_block = get_uniswap_swaps()
+        print("uniswap swap data downloaded")
         with open("uniswap_swaps.pickled", "bw+") as f:
             pickle.dump(swaps_by_block, f)
 

--- a/src/download_swaps.py
+++ b/src/download_swaps.py
@@ -3,14 +3,14 @@ import pickle
 import os
 
 
-def get_swaps(use_cache):
-    if os.path.exists("./uniswap_swaps.pickled") and use_cache:
-        with open("uniswap_swaps.pickled", "br") as f:
+def get_swaps(use_cache, filename):
+    if os.path.exists(filename) and use_cache:
+        with open(filename, "br") as f:
             swaps_by_block = pickle.load(f)
     else:
         swaps_by_block = get_uniswap_swaps()
         print("uniswap swap data downloaded")
-        with open("uniswap_swaps.pickled", "bw+") as f:
+        with open(filename, "bw+") as f:
             pickle.dump(swaps_by_block, f)
 
     return swaps_by_block

--- a/src/expected_value.py
+++ b/src/expected_value.py
@@ -17,7 +17,7 @@ print("Expected waiting time for opposite offer in block:")
 # The calculation makes the assumption that the appearance of a counter order
 # is independent of placing the random order.
 
-swaps_by_block = get_swaps(use_cache)
+swaps_by_block = get_swaps(use_cache, "data/uniswap_swaps.pickled")
 
 sorted_blocks = sorted(swaps_by_block.keys(), reverse=True)
 for focus_pair in focus_pairs:

--- a/src/expected_value.py
+++ b/src/expected_value.py
@@ -44,5 +44,5 @@ for focus_pair in focus_pairs:
     if last_probability > 0.98:
         print(expected_waiting_time_for_user)
     else:
-        print("Increase number_of_blocks_looking_forward go get \
-              a reasonable calculation")
+        print("Increase number_of_blocks_looking_forward to get"
+              "a reasonable calculation")

--- a/src/probability_of_match.py
+++ b/src/probability_of_match.py
@@ -1,9 +1,9 @@
-from .download_swaps import get_swaps
+# from .download_swaps import get_swaps
 from .utils import is_there_a_opposite_match_in_next_k_blocks
+from .read_csv import read_swaps_from_csv
 
 # Parameters
-use_cache = True
-waiting_time = 4
+waiting_time = 10
 threshold_for_showing_probability = 0.5
 
 print("Probability of match after waiting", waiting_time, "blocks")
@@ -14,7 +14,7 @@ print("Probability of match after waiting", waiting_time, "blocks")
 # is independent of placing the random order.
 
 
-swaps_by_block = get_swaps(use_cache)
+swaps_by_block = read_swaps_from_csv()
 sorted_blocks = sorted(swaps_by_block.keys(), reverse=True)
 focus_pairs = [
     [o['sellToken'], o['buyToken']]

--- a/src/probability_of_match.py
+++ b/src/probability_of_match.py
@@ -20,7 +20,7 @@ p(counter_order_in_next_k_blocks | order_in_this_block) = \
 """
 
 from .download_swaps import get_swaps
-from .utils import find_order_in_next_k_blocks
+from .utils import find_order_in_next_k_blocks, plot_match_survivor
 from .read_csv import read_swaps_from_csv
 
 # Parameters
@@ -38,6 +38,10 @@ if use_dune_data:
         'data/swaps_data_from_router.csv', consider_swaps_as_splitted_swaps)
 else:
     swaps_by_block = get_swaps(use_cache, "data/uniswap_swaps.pickled")
+
+for block in range(min(swaps_by_block.keys()), max(swaps_by_block.keys())):
+    if block not in swaps_by_block.keys():
+        swaps_by_block[block] = []
 
 # sorts blocks
 sorted_blocks = sorted(swaps_by_block.keys(), reverse=True)
@@ -93,3 +97,5 @@ for threshold in thresholds:
         if value > threshold:
             pairs_meeting_threshold += 1
     print(threshold, ":", pairs_meeting_threshold)
+
+plot_match_survivor(results)

--- a/src/probability_of_match.py
+++ b/src/probability_of_match.py
@@ -1,9 +1,11 @@
-# from .download_swaps import get_swaps
+from .download_swaps import get_swaps
 from .utils import is_there_a_opposite_match_in_next_k_blocks
 from .read_csv import read_swaps_from_csv
 
 # Parameters
-waiting_time = 10
+use_dune_data = True
+use_cache = True
+waiting_time = 4
 threshold_for_showing_probability = 0.5
 
 print("Probability of match after waiting", waiting_time, "blocks")
@@ -13,8 +15,11 @@ print("Probability of match after waiting", waiting_time, "blocks")
 # The calculation makes the assumption that the appearance of a counter order
 # is independent of placing the random order.
 
+if use_dune_data:
+    swaps_by_block = read_swaps_from_csv('data/swaps_data_from_router.csv')
+else:
+    swaps_by_block = get_swaps(use_cache, "data/uniswap_swaps.pickled")
 
-swaps_by_block = read_swaps_from_csv()
 sorted_blocks = sorted(swaps_by_block.keys(), reverse=True)
 focus_pairs = [
     [o['sellToken'], o['buyToken']]

--- a/src/probability_of_match.py
+++ b/src/probability_of_match.py
@@ -3,7 +3,7 @@ from .utils import is_there_a_opposite_match_in_next_k_blocks
 
 # Parameters
 use_cache = True
-waiting_time = 10
+waiting_time = 4
 threshold_for_showing_probability = 0.5
 
 print("Probability of match after waiting", waiting_time, "blocks")
@@ -22,7 +22,6 @@ focus_pairs = [
     for o in swaps_by_block.get(sorted_blocks[j], [])
 ]
 focus_pairs = list({(tuple(t)) for t in focus_pairs})
-focus_pairs.append(['WETH', 'USDT', 'DAI', 'USDC'])
 results = dict()
 for focus_pair in focus_pairs:
     nr_of_times_a_match_can_be_found = 0
@@ -48,3 +47,14 @@ for (key, value) in results.items():
 print(pairs_meeting_threshold / len(focus_pairs),
       " pairs of all pairs meet the threshold of a",
       threshold_for_showing_probability, " chance to find a match")
+
+
+print("An overview of the number of pairs matchable with different thresholds")
+thresholds = [0.2, 0.3, 0.4, 0.5, 0.6]
+
+for threshold in thresholds:
+    pairs_meeting_threshold = 0
+    for (key, value) in results.items():
+        if value > threshold:
+            pairs_meeting_threshold += 1
+    print(threshold, ":", pairs_meeting_threshold)

--- a/src/probability_of_match.py
+++ b/src/probability_of_match.py
@@ -1,5 +1,26 @@
+"""
+The following program calculates the probability of finding a match - a
+counter order - for a random order. 
+
+Formally, it computes,
+p(counter_order_in_next_k_blocks | order_in_this_block)
+
+The calculation makes the assumption that the appearance of an order and
+a counter order is independent.
+
+That is,
+p(counter_order_in_next_k_blocks, order_in_this_block) = \
+    p(counter_order_in_next_k_blocks) * p(order_in_this_block)
+
+Under this assumption,
+
+p(counter_order_in_next_k_blocks | order_in_this_block) = \
+    = p(counter_order_in_next_k_blocks, order_in_this_block) / p(order_in_this_block)
+    = p(counter_order_in_next_k_blocks) = p(order_in_next_k_blocks)
+"""
+
 from .download_swaps import get_swaps
-from .utils import is_there_a_opposite_match_in_next_k_blocks
+from .utils import find_order_in_next_k_blocks
 from .read_csv import read_swaps_from_csv
 
 # Parameters
@@ -10,12 +31,6 @@ waiting_time = 10
 threshold_for_showing_probability = 0.5
 
 print("Probability of match after waiting", waiting_time, "blocks")
-# Description
-# The following program calculates the probability of finding a match - a
-# counter order - for a random order.
-# The calculation makes the assumption that the appearance of a counter order
-# is independent of placing the random order.
-
 
 # Loads the data according to the set parameters
 if use_dune_data:
@@ -38,16 +53,18 @@ focus_pairs = list({(tuple(t)) for t in focus_pairs})
 # For each focus pair, it calculate the probability
 results = dict()
 for focus_pair in focus_pairs:
-    nr_of_times_a_match_can_be_found = 0
-    for i in range(len(sorted_blocks) - waiting_time):
-        if is_there_a_opposite_match_in_next_k_blocks(i,
-                                                      waiting_time,
-                                                      focus_pair,
-                                                      swaps_by_block,
-                                                      sorted_blocks):
-            nr_of_times_a_match_can_be_found += 1
+    nr_of_times_an_order_can_be_found = 0
+    for block_index in range(len(sorted_blocks) - waiting_time):
+        if find_order_in_next_k_blocks(
+            block_index,
+            waiting_time,
+            focus_pair,
+            swaps_by_block,
+            sorted_blocks
+        ):
+            nr_of_times_an_order_can_be_found += 1
 
-    prob_opposite_offer = nr_of_times_a_match_can_be_found / \
+    prob_opposite_offer = nr_of_times_an_order_can_be_found / \
         (len(sorted_blocks) - waiting_time)
     results["-".join(focus_pair)] = prob_opposite_offer
 

--- a/src/probability_of_match_assuming_statistical_dependence.py
+++ b/src/probability_of_match_assuming_statistical_dependence.py
@@ -14,7 +14,7 @@ p(counter_order_in_next_k_blocks, order_in_this_block) != \
 """
 
 from .download_swaps import get_swaps
-from .utils import find_order_in_block, find_order_in_next_k_blocks
+from .utils import find_order_in_block, find_order_in_next_k_blocks, plot_match_survivor
 from .read_csv import read_swaps_from_csv
 
 # Parameters
@@ -94,3 +94,5 @@ for threshold in thresholds:
         if value > threshold:
             pairs_meeting_threshold += 1
     print(threshold, ":", pairs_meeting_threshold)
+
+plot_match_survivor(results)

--- a/src/probability_of_match_assuming_statistical_dependence.py
+++ b/src/probability_of_match_assuming_statistical_dependence.py
@@ -9,8 +9,8 @@ focus_pair = {'WETH', 'DAI', 'USDC', 'USDT'}
 #focus_pair={'WETH', 'WBTC'}
 #focus_pair={'SUSHI', 'WETH'}
 
+swaps_by_block = get_swaps(use_cache, "data/uniswap_swaps.pickled")
 
-swaps_by_block = get_swaps(use_cache)
 
 # print(swaps_by_block)
 #print({frozenset([o['sellToken'], o['buyToken']]) for b in swaps_by_block.values() for o in b})

--- a/src/probability_of_match_assuming_statistical_dependence.py
+++ b/src/probability_of_match_assuming_statistical_dependence.py
@@ -1,109 +1,96 @@
+"""
+The following program calculates the probability of finding a match - a
+counter order - for a random order. 
+
+Formally, it computes,
+p(counter_order_in_next_k_blocks | order_in_this_block)
+
+The calculation makes the assumption that the appearance of an order and
+a counter order is NOT independent.
+
+That is,
+p(counter_order_in_next_k_blocks, order_in_this_block) != \
+    p(counter_order_in_next_k_blocks) * p(order_in_this_block)
+"""
+
 from .download_swaps import get_swaps
+from .utils import find_order_in_block, find_order_in_next_k_blocks
+from .read_csv import read_swaps_from_csv
 
-
-# Donwloading data from TheGraph takes a bit. When developing/debugging, enabling this
-# caches the results on disk.
+# Parameters
+use_dune_data = True
+consider_swaps_as_splitted_swaps = True
 use_cache = True
-focus_pair = {'WETH', 'DAI', 'USDC', 'USDT'}
-#focus_pair={'WETH', 'DAI', 'DAI' , 'DAI'}
-#focus_pair={'WETH', 'WBTC'}
-#focus_pair={'SUSHI', 'WETH'}
+waiting_time = 10
+threshold_for_showing_probability = 0.5
 
-swaps_by_block = get_swaps(use_cache, "data/uniswap_swaps.pickled")
+print("Probability of match after waiting", waiting_time, "blocks")
+
+# Loads the data according to the set parameters
+if use_dune_data:
+    swaps_by_block = read_swaps_from_csv(
+        'data/swaps_data_from_router.csv', consider_swaps_as_splitted_swaps)
+else:
+    swaps_by_block = get_swaps(use_cache, "data/uniswap_swaps.pickled")
+
+# sorts blocks
+sorted_blocks = sorted(swaps_by_block.keys(), reverse=True)
+
+# generates all possible pairs
+focus_pairs = [
+    [o['sellToken'], o['buyToken']]
+    for j in range(1, len(sorted_blocks) - 1)
+    for o in swaps_by_block.get(sorted_blocks[j], [])
+]
+focus_pairs = list({tuple(t) for t in focus_pairs})
+
+# For each focus pair, it calculate the probability
+results = dict()
+for focus_pair in focus_pairs:
+    nr_of_times_an_order_can_be_found = 0
+    nr_of_times_a_counter_order_can_be_found_if_order_is_found = 0
+    for start_block_index in range(len(sorted_blocks) - waiting_time):
+        if not find_order_in_block(
+            sorted_blocks[start_block_index], focus_pair, swaps_by_block
+        ):
+            continue
+        nr_of_times_an_order_can_be_found += 1
+        
+        nr_of_times_a_counter_order_can_be_found_if_order_is_found += \
+            find_order_in_next_k_blocks(
+                start_block_index,
+                waiting_time,
+                tuple(reversed(focus_pair)),
+                swaps_by_block,
+                sorted_blocks
+            )
+
+    prob_opposite_offer = nr_of_times_a_counter_order_can_be_found_if_order_is_found / \
+        nr_of_times_an_order_can_be_found if nr_of_times_an_order_can_be_found > 0 else 0
+    results["-".join(focus_pair)] = prob_opposite_offer
+
+# prints the pairs meeting the threshold: threshold_for_showing_probability
+
+pairs_meeting_threshold = 0
+for (key, value) in results.items():
+    if value > threshold_for_showing_probability:
+        print(key)
+        print(value)
+        pairs_meeting_threshold += 1
+
+print(pairs_meeting_threshold / len(focus_pairs),
+      " pairs of all pairs meet the threshold of a",
+      threshold_for_showing_probability, " chance to find a match")
 
 
-# print(swaps_by_block)
-#print({frozenset([o['sellToken'], o['buyToken']]) for b in swaps_by_block.values() for o in b})
-prob_opposite_offer = dict()
-prob_match = dict()
-expected_volume = dict()
-expected_nr_trades = dict()
+# prints the number of pairs with likelihoods above certain thresholds
 
-for k in range(20):
-    sorted_blocks = sorted(swaps_by_block.keys(), reverse=True)
-    nr_blocks_with_at_least_one_direct_trade = 0
-    nr_blocks_with_at_least_one_opposite_offer = 0
-    avg_volume = 0
-    nr_direct_trades = 0
-    for i in range(len(sorted_blocks) - k):
-        block_i = sorted_blocks[i]
-        sell_tokens_i = {o['sellToken']
-                         for o in swaps_by_block.get(block_i, [])}
-        buy_tokens_i = {o['buyToken'] for o in swaps_by_block.get(block_i, [])}
-        sell_tokens_j = {
-            o['sellToken']
-            for j in range(block_i, block_i + k + 1)
-            for o in swaps_by_block.get(j, [])
-        }
-        buy_tokens_j = {
-            o['buyToken']
-            for j in range(block_i, block_i + k + 1)
-            for o in swaps_by_block.get(j, [])
-        }
+print("An overview of the number of pairs matchable with different thresholds")
+thresholds = [0.2, 0.3, 0.4, 0.5, 0.6]
 
-        if focus_pair is not None:
-            t_1 = tuple(focus_pair)
-            t_2 = tuple(reversed(t_1))
-            found = False
-            singleTradeFound = False
-            if t_1[0] in buy_tokens_j and \
-                (t_1[1] in sell_tokens_j or
-                 (len(t_1) >= 3 and t_1[2] in sell_tokens_j) or
-                 (len(t_1) >= 4 and t_1[3] in sell_tokens_j)
-                 ):
-                nr_blocks_with_at_least_one_opposite_offer += 1
-            for t in [t_1, t_2]:
-                if t[0] in sell_tokens_i and t[0] in buy_tokens_j and \
-                        t[1] in buy_tokens_i and t[1] in sell_tokens_j:
-                    sell_tokens_i = buy_tokens_j = {t[0]}
-                    buy_tokens_i = sell_tokens_j = {t[1]}
-                    found = True
-                    break
-            if not found:
-                sell_tokens_i = sell_tokens_j = buy_tokens_i = buy_tokens_j = set()
-
-        common_tokens = (sell_tokens_i & buy_tokens_j) | (
-            sell_tokens_j & buy_tokens_i)
-        if len(common_tokens) > 0:
-            nr_blocks_with_at_least_one_direct_trade += 1
-            for t in common_tokens:
-                vols_selling_t_i = [
-                    float(o['volume'])
-                    for o in swaps_by_block.get(block_i, [])
-                    if o['sellToken'] == t
-                ]
-                vols_selling_t_j = [
-                    float(o['volume'])
-                    for j in range(block_i, block_i + k + 1)
-                    for o in swaps_by_block.get(j, [])
-                ]
-                avg_volume += sum(vols_selling_t_i) + sum(vols_selling_t_j)
-                nr_direct_trades += len(vols_selling_t_i) + \
-                    len(vols_selling_t_j)
-    if nr_direct_trades > 0:
-        avg_volume /= nr_direct_trades
-    else:
-        avg_volume = 0
-    prob_opposite_offer[k] = nr_blocks_with_at_least_one_opposite_offer / \
-        (len(sorted_blocks) - k)
-    prob_match[k] = nr_blocks_with_at_least_one_direct_trade / \
-        (len(sorted_blocks) - k)
-    expected_volume[k] = avg_volume
-    expected_nr_trades[k] = nr_direct_trades / \
-        nr_blocks_with_at_least_one_direct_trade
-
-print("Probability of opposite offer")
-for k, v in prob_opposite_offer.items():
-    print(v)
-
-print("Probability of trade")
-for k, v in prob_match.items():
-    print(k, v)
-
-print("Expected volume | trade exists")
-for k, v in expected_volume.items():
-    print(k, v)
-
-print("Expected nr trades | trade exists")
-for k, v in expected_nr_trades.items():
-    print(k, v)
+for threshold in thresholds:
+    pairs_meeting_threshold = 0
+    for (key, value) in results.items():
+        if value > threshold:
+            pairs_meeting_threshold += 1
+    print(threshold, ":", pairs_meeting_threshold)

--- a/src/probability_of_match_assuming_statistical_dependence.py
+++ b/src/probability_of_match_assuming_statistical_dependence.py
@@ -42,6 +42,7 @@ focus_pairs = [
     for j in range(1, len(sorted_blocks) - 1)
     for o in swaps_by_block.get(sorted_blocks[j], [])
 ]
+
 focus_pairs = list({tuple(t) for t in focus_pairs})
 
 # For each focus pair, it calculate the probability
@@ -95,4 +96,6 @@ for threshold in thresholds:
             pairs_meeting_threshold += 1
     print(threshold, ":", pairs_meeting_threshold)
 
-plot_match_survivor(results)
+print(results)
+#plot_match_survivor(results)
+

--- a/src/read_csv.py
+++ b/src/read_csv.py
@@ -1,0 +1,20 @@
+import csv
+
+
+def read_swaps_from_csv():
+    with open('data/swaps_data_from_router.csv', newline='') as f:
+        reader = csv.reader(f)
+        data = list(reader)
+        orders = dict()
+        for order in data:
+            path_data = order[5].split("'")
+            path_data = path_data[:-1]
+            if(len(path_data) > 1):
+                block_number = int(order[0])
+                list_start = orders[block_number] if block_number in \
+                    orders else list()
+                list_start.append(
+                    {"sellToken": path_data[1],
+                     'buyToken': path_data[-1]})
+                orders[block_number] = list_start
+        return orders

--- a/src/read_csv.py
+++ b/src/read_csv.py
@@ -2,7 +2,7 @@ import csv
 import ast
 
 
-def read_swaps_from_csv(filename):
+def read_swaps_from_csv(filename, read_swaps_splitted=False):
     with open(filename, newline='') as f:
         reader = csv.reader(f)
         data = list(reader)
@@ -20,8 +20,14 @@ def read_swaps_from_csv(filename):
             path = ['0x' + address for address in path]
             entry = orders[block_number] if block_number in \
                 orders else list()
-            entry.append(
-                {"sellToken": path[0],
-                 'buyToken': path[-1]})
+            if read_swaps_splitted:
+                for i in range(0, len(path)-1):
+                    entry.append(
+                        {"sellToken": path[i],
+                         'buyToken': path[i+1]})
+            else:
+                entry.append(
+                    {"sellToken": path[0],
+                     'buyToken': path[-1]})
             orders[block_number] = entry
         return orders

--- a/src/read_csv.py
+++ b/src/read_csv.py
@@ -18,6 +18,7 @@ def read_swaps_from_csv(filename, read_swaps_splitted=False):
 
             path = ast.literal_eval(path)
             path = ['0x' + address for address in path]
+            block_number = int(block_number)
             entry = orders[block_number] if block_number in \
                 orders else list()
             if read_swaps_splitted:

--- a/src/read_csv.py
+++ b/src/read_csv.py
@@ -1,20 +1,27 @@
 import csv
+import ast
 
 
-def read_swaps_from_csv():
-    with open('data/swaps_data_from_router.csv', newline='') as f:
+def read_swaps_from_csv(filename):
+    with open(filename, newline='') as f:
         reader = csv.reader(f)
         data = list(reader)
         orders = dict()
-        for order in data:
-            path_data = order[5].split("'")
-            path_data = path_data[:-1]
-            if(len(path_data) > 1):
-                block_number = int(order[0])
-                list_start = orders[block_number] if block_number in \
-                    orders else list()
-                list_start.append(
-                    {"sellToken": path_data[1],
-                     'buyToken': path_data[-1]})
-                orders[block_number] = list_start
+        first = True
+        for row in data:
+            # Skip header.
+            if first:
+                first = False
+                continue
+            (block_number, index, gas_price, sell_amount,
+             buy_amount, path, address, output_amounts) = row
+
+            path = ast.literal_eval(path)
+            path = ['0x' + address for address in path]
+            entry = orders[block_number] if block_number in \
+                orders else list()
+            entry.append(
+                {"sellToken": path[0],
+                 'buyToken': path[-1]})
+            orders[block_number] = entry
         return orders

--- a/src/subgraph.py
+++ b/src/subgraph.py
@@ -6,7 +6,7 @@ from functools import partial
 
 
 class GraphQLClient:
-    page_size = 1000
+    page_size = 500
 
     def __init__(self, url):
         self.endpoint = HTTPEndpoint(self.url)
@@ -88,4 +88,3 @@ class UniswapClient(GraphQLClient):
     def get_swaps(self, transactions_filter=dict()):
         """Get swap transactions."""
         return self.paginated(partial(self.get_swaps_page, transactions_filter))
-

--- a/src/utils.py
+++ b/src/utils.py
@@ -18,3 +18,21 @@ def find_order_in_next_k_blocks(
         if find_order_in_block(sorted_blocks[block_index], focus_pair, swaps_by_block):
             return True
     return False
+
+def plot_match_survivor(results, filename=None):
+    """If filename is not None then creates file on disk."""
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.hist(
+        results.values(),
+        bins=20,
+        density=False,
+        cumulative=-1,
+        log=True
+    )
+    plt.title('Number of matchable pairs')
+    plt.xlabel('x')
+    plt.ylabel('Nr pairs with probability of match >= x')
+    if filename is not None:
+        plt.savefig(filename)
+    plt.show()    

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,12 +3,7 @@ def is_there_a_opposite_match_in_next_k_blocks(startblock, k, focus_pair,
     for j in range(startblock, startblock + k):
         for o in swaps_by_block.get(sorted_blocks[j], []):
             if focus_pair is not None:
-                if focus_pair[0] in o['buyToken'] and \
-                    (focus_pair[1] in o['sellToken'] or
-                     (len(focus_pair) >= 3 and focus_pair[2]
-                         in o['sellToken']) or
-                     (len(focus_pair) >=
-                      4 and focus_pair[3] in o['sellToken'])
-                     ):
+                if focus_pair[0] == o['buyToken'] and \
+                        focus_pair[1] == o['sellToken']:
                     return True
     return False

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,20 @@
-def is_there_a_opposite_match_in_next_k_blocks(startblock, k, focus_pair,
-                                               swaps_by_block, sorted_blocks):
-    for j in range(startblock, startblock + k):
-        for o in swaps_by_block.get(sorted_blocks[j], []):
-            if focus_pair is not None:
-                if focus_pair[0] == o['buyToken'] and \
-                        focus_pair[1] == o['sellToken']:
-                    return True
+def find_order_in_block(
+    block, focus_pair,
+    swaps_by_block
+):
+    for o in swaps_by_block.get(block, []):
+        if focus_pair[0] == o['buyToken'] and \
+           focus_pair[1] == o['sellToken']:
+            return True
+    return False
+
+
+def find_order_in_next_k_blocks(
+    start_block_index, k, focus_pair,
+    swaps_by_block, sorted_blocks
+):
+    assert focus_pair is not None
+    for block_index in range(start_block_index, start_block_index + k):
+        if find_order_in_block(sorted_blocks[block_index], focus_pair, swaps_by_block):
+            return True
     return False


### PR DESCRIPTION
This PR add the csv reader, reading the data from the dune queries:
https://explore.duneanalytics.com/queries/12099/source?p_from_block=11090000&p_to_block=11093010

I published the data of running:
```
python -m src.probability_of_match
```
here: 
https://docs.google.com/document/d/1l04TJQbFU2c8KUXS3F5jRtHGpVwu-9kI4hrLT8TwpoM/edit?ts=5f8ff523#heading=h.kmvji8lux5ou

Please double check that the results are making sense. To me, they are looking terribly bad. Initially, the numbers were looking much better, when we looked at all the swaps happening and not just at the trades from the routers...

But imo, it really makes more senses to look at the orders from routers, as we can not easily split trades: An UNI->USDT trade, which is split internally as two trades: UNI->ETH, ETH->USDT can not be split by our platform in the first MVP
